### PR TITLE
fix(foundry-vtt): bad annotations indentation in ingress template

### DIFF
--- a/charts/foundry-vtt/templates/ingress.yaml
+++ b/charts/foundry-vtt/templates/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
       {{- template "configurationSnippet" . }}
 {{- end }}
 {{- if .Values.ingress.annotations }}
-  {{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{- toYaml .Values.ingress.annotations | nindent 4 }}
 {{- end }}
 spec:
 {{- if .Values.ingress.ingressClassName }}


### PR DESCRIPTION
This PR fixes annotations indentation in the ingress template, adding more than one `ingress.annotations` triggers the bug:

```bash
$ helm template --repo https://helm.mahahe.it/ foundry-vtt --set ingress.enabled=true,ingress.annotations.test1=test,ingress.annotations.test2=test --show-only templates/ingress.yaml --debug
```