### PR TITLE
Change foundryvtt probe url

### DIFF
--- a/charts/foundry-vtt/templates/deployment.yaml
+++ b/charts/foundry-vtt/templates/deployment.yaml
@@ -45,12 +45,12 @@ spec:
             periodSeconds: 25
           {{- end }}
             httpGet:
-              path: /
+              path: /api/status
               port: http
           readinessProbe:
             initialDelaySeconds: 30
             httpGet:
-              path: /
+              path: /api/status
               port: http
           resources:
           {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
This PR adjusts the liveness/readiness probe url to the [one used by the healthcheck in the Docker container](https://github.com/felddy/foundryvtt-docker/blob/develop/src/check_health.sh). It's probably a good idea to match those, and also avoid hammering the main page with requests.