### PR TITLE
Explicitly set foundryvtt pod hostname

### DIFF
--- a/charts/foundry-vtt/templates/deployment.yaml
+++ b/charts/foundry-vtt/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      hostname: {{ include "foundry-vtt.fullname" . }}
       serviceAccountName: {{ include "foundry-vtt.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
Foundry uses the hostname to check whether the user has already accepted the license agreement. Because Deployment pod names are randomized, this will cause Foundry to show the license prompt every time the pod is recreated, such as when draining the node to upgrade.

Alternatively this could be fixed using a StatefulSet instead of a Deployment, but that would require non-insignificant refactoring of the pod, and besides, fixing the hostname like that shouldn't cause any issues since Foundry doesn't support running multiple copies at once.